### PR TITLE
Prevent system calls in tests

### DIFF
--- a/spec/baes_spec.rb
+++ b/spec/baes_spec.rb
@@ -5,7 +5,21 @@ RSpec.describe Baes do
     expect(Baes::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(true).to eq(true)
+  it "does not allow backtick system calls" do
+    message =
+      "Don't use system calls. Use `Open3.capture3` instead. " \
+      "Called with `echo 'blah'`"
+
+    expect { `echo 'blah'` }
+      .to raise_error(TestingError, message)
+  end
+
+  it "does not allow system calls" do
+    message =
+      "Don't use system calls. Use `Open3.capture3` instead. " \
+      "Called with `echo 'blah'`"
+
+    expect { system("echo 'blah'") }
+      .to raise_error(TestingError, message)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,22 @@ end
 
 require "baes"
 
+class TestingError < StandardError; end
+
+module Kernel
+  def `(command)
+    raise TestingError,
+          "Don't use system calls. " \
+          "Use `Open3.capture3` instead. Called with `#{command}`"
+  end
+
+  def system(command)
+    raise TestingError,
+          "Don't use system calls. " \
+          "Use `Open3.capture3` instead. Called with `#{command}`"
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
@@ -17,5 +33,9 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before do
+    allow(Open3).to receive(:capture3)
   end
 end


### PR DESCRIPTION
This replaces `` Kernel#` `` and `Kernel#system` to prevent using them in
`Baes` code. Instead we should prefer using `Open3.capture3` for
consistency and so that we can easily stub them out.

Also stub out `Open3.capture3` to prevent accidentally making system
calls in tests.
