### PR TITLE
Support `rebase-merge` directory

### DIFF
--- a/lib/baes/git.rb
+++ b/lib/baes/git.rb
@@ -54,11 +54,19 @@ module Baes::Git
 
   # return the commit number the rebase is currently halted on
   def self.next_rebase_step
-    Integer(File.read("./.git/rebase-apply/next"))
+    if Dir.exist?("./.git/rebase-apply")
+      Integer(File.read("./.git/rebase-apply/next"))
+    else
+      Integer(File.read("./.git/rebase-merge/msgnum"))
+    end
   end
 
   # return the number of commits in the rebase
   def self.last_rebase_step
-    Integer(File.read("./.git/rebase-apply/last"))
+    if Dir.exist?("./.git/rebase-apply")
+      Integer(File.read("./.git/rebase-apply/last"))
+    else
+      Integer(File.read("./.git/rebase-merge/end"))
+    end
   end
 end

--- a/spec/baes/git_spec.rb
+++ b/spec/baes/git_spec.rb
@@ -112,8 +112,18 @@ RSpec.describe Baes::Git do
   end
 
   describe "#next_rebase_step" do
-    it "returns the contents of the next rebase file" do
-      path = "./.git/rebase-apply/next"
+    it "returns the contents of the next rebase file when rebase-apply" do
+      path = "./.git/rebase-apply"
+      expect(Dir).to receive(:exist?).with(path).and_return(true)
+      expect(File).to receive(:read).with("#{path}/next").and_return("42\n")
+
+      expect(described_class.next_rebase_step).to eq(42)
+    end
+
+    it "returns the contents of the next rebase file when rebase-merge" do
+      apply_path = "./.git/rebase-apply"
+      path = "./.git/rebase-merge/msgnum"
+      expect(Dir).to receive(:exist?).with(apply_path).and_return(false)
       expect(File).to receive(:read).with(path).and_return("42\n")
 
       expect(described_class.next_rebase_step).to eq(42)
@@ -121,8 +131,18 @@ RSpec.describe Baes::Git do
   end
 
   describe "#last_rebase_step" do
-    it "returns the contents of the last rebase file" do
-      path = "./.git/rebase-apply/last"
+    it "returns the contents of the last rebase file when rebase-apply" do
+      path = "./.git/rebase-apply"
+      expect(Dir).to receive(:exist?).with(path).and_return(true)
+      expect(File).to receive(:read).with("#{path}/last").and_return("51\n")
+
+      expect(described_class.last_rebase_step).to eq(51)
+    end
+
+    it "returns the contents of the last rebase file when rebase-merge" do
+      apply_path = "./.git/rebase-apply"
+      path = "./.git/rebase-merge/end"
+      expect(Dir).to receive(:exist?).with(apply_path).and_return(false)
       expect(File).to receive(:read).with(path).and_return("51\n")
 
       expect(described_class.last_rebase_step).to eq(51)


### PR DESCRIPTION
In some cases it appears `git rebase` will create a `rebase-merge`
directory rather than a `rebase-apply` directory. I'm not sure why this
is, but [the git prompt code][gp] also handles both of these cases, so
seems like this is the way to handle it.

[gp]: https://github.com/git/git/blob/bcd6bc478adc4951d57ec597c44b12ee74bc88fb/contrib/completion/git-prompt.sh#L452-L463
