### PR TITLE
Feature: allow ignoring specific branches

### DIFF
--- a/lib/baes/configuration.rb
+++ b/lib/baes/configuration.rb
@@ -44,6 +44,16 @@ module Baes::Configuration
     @root_name = root_name
   end
 
+  # return the configured ignored branches
+  def self.ignored_branch_names
+    @ignored_branch_names ||= []
+  end
+
+  # allow setting the ignored branch names
+  def self.ignored_branch_names=(ignored_branch_names)
+    @ignored_branch_names = ignored_branch_names
+  end
+
   # return whether dry run mode has been enabled
   def self.dry_run?
     !!@dry_run
@@ -72,6 +82,7 @@ module Baes::Configuration
     configure_help(parser)
     configure_root_name(parser)
     configure_auto_skip(parser)
+    configure_ignored_branches(parser)
 
     parser.parse(options)
   end
@@ -94,6 +105,11 @@ module Baes::Configuration
   # return the configured root name if given
   def root_name
     Baes::Configuration.root_name
+  end
+
+  # return the configured ignored branch names
+  def ignored_branch_names
+    Baes::Configuration.ignored_branch_names
   end
 
   # return whether dry run has been enabled
@@ -127,6 +143,13 @@ module Baes::Configuration
     message = "automatically skip all but the most recent commit"
     parser.on("--auto-skip", message) do
       Baes::Configuration.auto_skip = true
+    end
+  end
+
+  def configure_ignored_branches(parser)
+    message = "don't rebase specified branches or their child branches"
+    parser.on("-i", "--ignore BRANCH1,BRANCH2", Array, message) do |branches|
+      Baes::Configuration.ignored_branch_names += branches
     end
   end
 end

--- a/lib/baes/tree_builder.rb
+++ b/lib/baes/tree_builder.rb
@@ -4,6 +4,8 @@ SKIP_BRANCHES = ["staging", "main", "master"].freeze
 
 # class that generates a tree of dependent branches
 class Baes::TreeBuilder
+  include Baes::Configuration
+
   # generate a tree of Branch records linked to their children
   def call(branches, root_branch:)
     indexed_branches = index_branches(branches)
@@ -11,9 +13,19 @@ class Baes::TreeBuilder
     branches.each do |branch|
       link_branch_to_parent(branch, indexed_branches, root_branch: root_branch)
     end
+
+    prune(root_branch)
   end
 
   private
+
+  def prune(branch)
+    branch.children.delete_if do |child|
+      ignored_branch_names.include?(child.name)
+    end
+
+    branch.children.each { |child| prune(child) }
+  end
 
   def link_branch_to_parent(branch, indexed_branches, root_branch:)
     return if branch == root_branch || SKIP_BRANCHES.include?(branch.name)

--- a/spec/baes/configuration_spec.rb
+++ b/spec/baes/configuration_spec.rb
@@ -16,5 +16,12 @@ RSpec.describe Baes::Configuration do
 
       expect(Baes::Configuration.auto_skip?).to be(true)
     end
+
+    it "configures ignored branches given --ignore" do
+      load_options(["--ignore", "branch_a,branch_b"])
+
+      expected_branches = ["branch_a", "branch_b"]
+      expect(Baes::Configuration.ignored_branch_names).to eq(expected_branches)
+    end
   end
 end

--- a/spec/baes/tree_builder_spec.rb
+++ b/spec/baes/tree_builder_spec.rb
@@ -63,5 +63,30 @@ RSpec.describe Baes::TreeBuilder do
       expect { described_class.new.call(branches, root_branch: branch1) }
         .to raise_error(Baes::Error, message)
     end
+
+    it "prunes ignored branches" do
+      Baes::Configuration.ignored_branch_names = ["some_branch_10"]
+      branch1 = Baes::Branch.new("main")
+      branch2 = Baes::Branch.new("some_branch_9")
+      branch3 = Baes::Branch.new("some_branch_10")
+      branches = [branch1, branch2, branch3]
+
+      described_class.new.call(branches, root_branch: branch1)
+
+      expect(branch1.children).to eq([branch2])
+      expect(branch2.children).to be_empty
+    end
+
+    it "prunes descendant branches" do
+      Baes::Configuration.ignored_branch_names = ["some_branch_9"]
+      branch1 = Baes::Branch.new("main")
+      branch2 = Baes::Branch.new("some_branch_9")
+      branch3 = Baes::Branch.new("some_branch_10")
+      branches = [branch1, branch2, branch3]
+
+      described_class.new.call(branches, root_branch: branch1)
+
+      expect(branch1.children).to be_empty
+    end
   end
 end


### PR DESCRIPTION
This will prevent the specified branches from being rebased, as well as
any child branches.
