### PR TITLE
Reset configuration in tests

### DIFF
--- a/lib/baes/configuration.rb
+++ b/lib/baes/configuration.rb
@@ -103,4 +103,11 @@ module Baes::Configuration
   def dry_run?
     Baes::Configuration.dry_run?
   end
+
+  # clear all configuration
+  def self.reset
+    instance_variables.each do |ivar|
+      remove_instance_variable(ivar)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ require_relative "support/stub_system"
 class TestingError < StandardError; end
 
 RSpec.configure do |config|
+  config.order = :random
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
@@ -25,5 +27,9 @@ RSpec.configure do |config|
 
   config.expect_with(:rspec) do |c|
     c.syntax = :expect
+  end
+
+  config.after do
+    Baes::Configuration.reset
   end
 end


### PR DESCRIPTION
There was some configuration bleeding between tests which caused errors
in other changes when they changed the test order.
