### PR TITLE
remove confirmation when there is a rebase conflict

### DIFF
--- a/lib/baes/branch.rb
+++ b/lib/baes/branch.rb
@@ -42,7 +42,7 @@ class Baes::Branch
   private
 
   def skip_through(other_branch)
-    if auto_skip? || confirm_skip(other_branch) == "y"
+    if auto_skip?
       result = git.rebase_skip
 
       skip_through(other_branch) unless result.success?
@@ -51,21 +51,8 @@ class Baes::Branch
     end
   end
 
-  def confirm_skip(other_branch)
-    output.puts("conflict rebasing branch #{name} on #{other_branch.name}")
-    output.print(skip_rebase_message)
-    answer = input.gets.chomp
-    output.puts
-
-    answer
-  end
-
   def auto_skip?
     Baes::Configuration.auto_skip? &&
       git.next_rebase_step < git.last_rebase_step
-  end
-
-  def skip_rebase_message
-    "skip commit #{git.next_rebase_step} of #{git.last_rebase_step}? (y/n)"
   end
 end

--- a/spec/baes/branch_spec.rb
+++ b/spec/baes/branch_spec.rb
@@ -13,28 +13,6 @@ RSpec.describe Baes::Branch do
     end
 
     context "when rebase is not successful" do
-      it "skips when the user enters 'y'" do
-        branch = described_class.new("my_branch")
-        other_branch = described_class.new("other_branch")
-        FakeGit.rebases_successful = [false, true]
-        input.puts("y\n")
-        input.rewind
-
-        expect { branch.rebase(other_branch) }
-          .to rebase("my_branch").on("other_branch")
-      end
-
-      it "continues the skip when there are more conflicts" do
-        branch = described_class.new("my_branch")
-        other_branch = described_class.new("other_branch")
-        FakeGit.rebases_successful = [false, false, true]
-        input.puts("y\ny\n")
-        input.rewind
-
-        expect { branch.rebase(other_branch) }
-          .to rebase("my_branch").on("other_branch")
-      end
-
       it "continues the skip up to the last commit when auto skip" do
         branch = described_class.new("my_branch")
         other_branch = described_class.new("other_branch")


### PR DESCRIPTION
Better to bail and let the user address it manually.
