### PR TITLE
Rubocop: prefer class << self syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ Bundler/GemVersion: { EnforcedStyle: forbidden }
 Metrics/BlockLength: { Exclude: ["spec/**/*_spec.rb"] }
 RSpec/MessageExpectation: { EnforcedStyle: expect }
 Style/ClassAndModuleChildren: { EnforcedStyle: compact }
+Style/ClassMethodsDefinitions: { EnforcedStyle: self_class }
 
 Style/MethodCallWithArgsParentheses:
   AllowedMethods:

--- a/lib/baes/actions/run.rb
+++ b/lib/baes/actions/run.rb
@@ -2,21 +2,23 @@
 
 # top-level class to parse options and run the command
 module Baes::Actions::Run
-  # parse options and execute command
-  def self.call(options)
-    case options.first
-    when "bisect"
-      Baes::Actions::Bisect.call(options[1..].join(" "))
-    when "rebase"
-      Baes::Actions::LoadRebaseConfiguration.call(options)
+  class << self
+    # parse options and execute command
+    def call(options)
+      case options.first
+      when "bisect"
+        Baes::Actions::Bisect.call(options[1..].join(" "))
+      when "rebase"
+        Baes::Actions::LoadRebaseConfiguration.call(options)
 
-      Baes::Actions::Rebase.call
-    when nil
-      Baes::Actions::LoadConfiguration.call(["-h"])
-    when /^-/
-      Baes::Actions::LoadConfiguration.call(options)
-    else
-      abort("Invalid command #{options.inspect}")
+        Baes::Actions::Rebase.call
+      when nil
+        Baes::Actions::LoadConfiguration.call(["-h"])
+      when /^-/
+        Baes::Actions::LoadConfiguration.call(options)
+      else
+        abort("Invalid command #{options.inspect}")
+      end
     end
   end
 end

--- a/lib/baes/configuration.rb
+++ b/lib/baes/configuration.rb
@@ -2,88 +2,76 @@
 
 # module to allow configuring various Baes settings
 module Baes::Configuration
-  # return the git wrapper in use, Baes::Git by default
-  def self.git
-    @git ||= Baes::Git
-  end
+  class << self
+    # return the git wrapper in use, Baes::Git by default
+    def git
+      @git ||= Baes::Git
+    end
 
-  # allow setting the git wrapper, useful in tests
-  def self.git=(git)
-    @git = git
-  end
+    # allow setting the git wrapper, useful in tests
+    attr_writer :git
 
-  # return the input stream, $stdin by default
-  def self.input
-    @input ||= $stdin
-  end
+    # return the input stream, $stdin by default
+    def input
+      @input ||= $stdin
+    end
 
-  # allow setting the input stream, useful in tests
-  def self.input=(input)
-    @input = input
-  end
+    # allow setting the input stream, useful in tests
+    attr_writer :input
 
-  # return the output stream, $stdout by default
-  def self.output
-    @output ||= $stdout
-  end
+    # return the output stream, $stdout by default
+    def output
+      @output ||= $stdout
+    end
 
-  # allow setting the output stream, useful in tests
-  def self.output=(output)
-    @output = output
-  end
+    # allow setting the output stream, useful in tests
+    attr_writer :output
 
-  # return the configured root_name
-  def self.root_name
-    @root_name ||=
-      begin
-        root = (["main", "master"] & git.branch_names).first
+    # return the configured root_name
+    def root_name
+      @root_name ||=
+        begin
+          root = (["main", "master"] & git.branch_names).first
 
-        message = "unable to infer root branch, please specify with -r"
-        raise Baes::Git::GitError, message unless root
+          message = "unable to infer root branch, please specify with -r"
+          raise Baes::Git::GitError, message unless root
 
-        root
+          root
+        end
+    end
+
+    # allow setting the root_name
+    attr_writer :root_name
+
+    # return the configured ignored branches
+    def ignored_branch_names
+      @ignored_branch_names ||= []
+    end
+
+    # allow setting the ignored branch names
+    attr_writer :ignored_branch_names
+
+    # return whether dry run mode has been enabled
+    def dry_run?
+      !!@dry_run
+    end
+
+    # allow setting dry run mode
+    attr_writer :dry_run
+
+    # return whether auto skip mode has been enabled
+    def auto_skip?
+      !!@auto_skip
+    end
+
+    # allow setting auto skip mode
+    attr_writer :auto_skip
+
+    # clear all configuration
+    def reset
+      instance_variables.each do |ivar|
+        remove_instance_variable(ivar)
       end
-  end
-
-  # allow setting the root_name
-  def self.root_name=(root_name)
-    @root_name = root_name
-  end
-
-  # return the configured ignored branches
-  def self.ignored_branch_names
-    @ignored_branch_names ||= []
-  end
-
-  # allow setting the ignored branch names
-  def self.ignored_branch_names=(ignored_branch_names)
-    @ignored_branch_names = ignored_branch_names
-  end
-
-  # return whether dry run mode has been enabled
-  def self.dry_run?
-    !!@dry_run
-  end
-
-  # allow setting dry run mode
-  def self.dry_run=(dry_run)
-    @dry_run = dry_run
-  end
-
-  # return whether auto skip mode has been enabled
-  def self.auto_skip?
-    !!@auto_skip
-  end
-
-  # allow setting auto skip mode
-  def self.auto_skip=(auto_skip)
-    @auto_skip = auto_skip
-  end
-
-  # clear all configuration
-  def self.reset
-    instance_variables.each do |ivar|
-      remove_instance_variable(ivar)
     end
   end
 end

--- a/lib/baes/git.rb
+++ b/lib/baes/git.rb
@@ -9,75 +9,77 @@ module Baes::Git
 
   class GitError < StandardError; end
 
-  # checkout git branch and raise error on failure
-  def self.checkout(branch_name)
-    stdout, stderr, status = Open3.capture3("git checkout #{branch_name}")
+  class << self
+    # checkout git branch and raise error on failure
+    def checkout(branch_name)
+      stdout, stderr, status = Open3.capture3("git checkout #{branch_name}")
 
-    output.puts(stdout)
-    output.puts(stderr) unless stderr.empty?
+      output.puts(stdout)
+      output.puts(stderr) unless stderr.empty?
 
-    return if status.success?
+      return if status.success?
 
-    raise GitError, "failed to rebase on '#{branch_name}'"
-  end
-
-  # rebase current branch on given branch name and return status
-  def self.rebase(branch_name)
-    stdout, stderr, status = Open3.capture3("git rebase #{branch_name}")
-
-    output.puts(stdout)
-    output.puts(stderr) unless stderr.empty?
-
-    status
-  end
-
-  # get current branch name and raise on error
-  def self.current_branch_name
-    stdout, stderr, status = Open3.capture3("git rev-parse --abbrev-ref HEAD")
-
-    output.puts(stderr) unless stderr.empty?
-
-    raise GitError, "failed to get current branch" unless status.success?
-
-    stdout.strip
-  end
-
-  # list branch names and raise on failure
-  def self.branch_names
-    stdout, stderr, status = Open3.capture3("git branch")
-
-    output.puts(stderr) unless stderr.empty?
-
-    raise GitError, "failed to get branches" unless status.success?
-
-    stdout.lines.map { |line| line.sub(/^\*/, "").strip }
-  end
-
-  # skip current commit during rebase and return status
-  def self.rebase_skip
-    stdout, stderr, status = Open3.capture3("git rebase --skip")
-
-    output.puts(stdout)
-    output.puts(stderr) unless stderr.empty?
-
-    status
-  end
-
-  # return the commit number the rebase is currently halted on
-  def self.next_rebase_step
-    if Dir.exist?("./.git/rebase-apply")
-      Integer(File.read("./.git/rebase-apply/next"))
-    else
-      Integer(File.read("./.git/rebase-merge/msgnum"))
+      raise GitError, "failed to rebase on '#{branch_name}'"
     end
-  end
 
-  # return the number of commits in the rebase
-  def self.last_rebase_step
-    if Dir.exist?("./.git/rebase-apply")
-      Integer(File.read("./.git/rebase-apply/last"))
-    else
-      Integer(File.read("./.git/rebase-merge/end"))
+    # rebase current branch on given branch name and return status
+    def rebase(branch_name)
+      stdout, stderr, status = Open3.capture3("git rebase #{branch_name}")
+
+      output.puts(stdout)
+      output.puts(stderr) unless stderr.empty?
+
+      status
+    end
+
+    # get current branch name and raise on error
+    def current_branch_name
+      stdout, stderr, status = Open3.capture3("git rev-parse --abbrev-ref HEAD")
+
+      output.puts(stderr) unless stderr.empty?
+
+      raise GitError, "failed to get current branch" unless status.success?
+
+      stdout.strip
+    end
+
+    # list branch names and raise on failure
+    def branch_names
+      stdout, stderr, status = Open3.capture3("git branch")
+
+      output.puts(stderr) unless stderr.empty?
+
+      raise GitError, "failed to get branches" unless status.success?
+
+      stdout.lines.map { |line| line.sub(/^\*/, "").strip }
+    end
+
+    # skip current commit during rebase and return status
+    def rebase_skip
+      stdout, stderr, status = Open3.capture3("git rebase --skip")
+
+      output.puts(stdout)
+      output.puts(stderr) unless stderr.empty?
+
+      status
+    end
+
+    # return the commit number the rebase is currently halted on
+    def next_rebase_step
+      if Dir.exist?("./.git/rebase-apply")
+        Integer(File.read("./.git/rebase-apply/next"))
+      else
+        Integer(File.read("./.git/rebase-merge/msgnum"))
+      end
+    end
+
+    # return the number of commits in the rebase
+    def last_rebase_step
+      if Dir.exist?("./.git/rebase-apply")
+        Integer(File.read("./.git/rebase-apply/last"))
+      else
+        Integer(File.read("./.git/rebase-merge/end"))
+      end
     end
   end
 end

--- a/spec/support/fake_git.rb
+++ b/spec/support/fake_git.rb
@@ -15,78 +15,64 @@ end
 module FakeGit
   ### GIT METHODS ###
 
-  def self.checkout(branch_name)
-    self.current_branch_name = branch_name
-  end
-
-  def self.rebase(base_branch_name)
-    rebases << [current_branch_name, base_branch_name]
-
-    FakeStatus.new(success: next_success)
-  end
-
-  def self.branch_names
-    @branch_names ||= []
-  end
-
-  def self.rebase_skip
-    FakeStatus.new(success: next_success)
-  end
-
-  def self.next_rebase_step
-    rebase_index
-  end
-
-  def self.last_rebase_step
-    rebases_successful.length
-  end
-
-  ### TEST METHODS ###
-
-  def self.next_success
-    if rebases_successful.any?
-      self.rebase_index += 1
-      rebases_successful[rebase_index - 1]
-    else
-      true
+  class << self
+    def checkout(branch_name)
+      self.current_branch_name = branch_name
     end
-  end
 
-  def self.rebases
-    @rebases ||= []
-  end
+    def rebase(base_branch_name)
+      rebases << [current_branch_name, base_branch_name]
 
-  def self.rebase_index
-    @rebase_index ||= 0
-  end
+      FakeStatus.new(success: next_success)
+    end
 
-  def self.rebase_index=(rebase_index)
-    @rebase_index = rebase_index
-  end
+    def branch_names
+      @branch_names ||= []
+    end
 
-  def self.current_branch_name=(branch_name)
-    @current_branch_name = branch_name
-  end
+    def rebase_skip
+      FakeStatus.new(success: next_success)
+    end
 
-  def self.current_branch_name
-    @current_branch_name
-  end
+    def next_rebase_step
+      rebase_index
+    end
 
-  def self.branch_names=(branch_names)
-    @branch_names = branch_names
-  end
+    def last_rebase_step
+      rebases_successful.length
+    end
 
-  def self.rebases_successful
-    @rebases_successful ||= []
-  end
+    ### TEST METHODS ###
 
-  def self.rebases_successful=(rebases_successful)
-    @rebases_successful = rebases_successful
-  end
+    def next_success
+      if rebases_successful.any?
+        self.rebase_index += 1
+        rebases_successful[rebase_index - 1]
+      else
+        true
+      end
+    end
 
-  def self.reset
-    instance_variables.each do |ivar|
-      remove_instance_variable(ivar)
+    def rebases
+      @rebases ||= []
+    end
+
+    def rebase_index
+      @rebase_index ||= 0
+    end
+
+    attr_writer :rebase_index, :branch_names, :rebases_successful
+
+    attr_accessor :current_branch_name
+
+    def rebases_successful
+      @rebases_successful ||= []
+    end
+
+    def reset
+      instance_variables.each do |ivar|
+        remove_instance_variable(ivar)
+      end
     end
   end
 end

--- a/spec/support/matchers/capture_configured_output.rb
+++ b/spec/support/matchers/capture_configured_output.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 
 module CaptureConfiguredOutput
-  def self.name
-    "configured output"
-  end
+  class << self
+    def name
+      "configured output"
+    end
 
-  def self.capture(block)
-    old_output = Baes::Configuration.output
-    new_output = StringIO.new
-    Baes::Configuration.output = new_output
+    def capture(block)
+      old_output = Baes::Configuration.output
+      new_output = StringIO.new
+      Baes::Configuration.output = new_output
 
-    block.call
+      block.call
 
-    new_output.string
-  ensure
-    Baes::Configuration.output = old_output
+      new_output.string
+    ensure
+      Baes::Configuration.output = old_output
+    end
   end
 end
 


### PR DESCRIPTION
**Why**

If we want to have private methods, then we have to use `class << self`.
Having all modules use this format consistently makes diffs smaller when
new private methods are added, since we don't need to switch syntax.
