### PR TITLE
shorten message when deleting branches

### DIFF
--- a/lib/baes/git.rb
+++ b/lib/baes/git.rb
@@ -77,7 +77,7 @@ module Baes::Git
     def delete_branches(branch_names)
       return if branch_names.empty?
 
-      output.puts("deleting branches: #{branch_names.join(", ")}")
+      output.puts("deleting branches")
       output.puts(run_or_raise("git branch -d #{branch_names.join(" ")}"))
     end
 

--- a/spec/baes/git_spec.rb
+++ b/spec/baes/git_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Baes::Git do
 
       described_class.delete_branches(["branch1", "branch2"])
 
-      expect(output.string).to eq("deleting branches: branch1, branch2\nout\n")
+      expect(output.string).to eq("deleting branches\nout\n")
     end
 
     it "returns early when branch_names is empty" do


### PR DESCRIPTION
It's a noisy line, and we print out the branches that are deleted
immediately afterwards.
